### PR TITLE
feat(main): add command-line flags for TCA9548A address and channel

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func getDevice(bus i2c.BusCloser, tcaAddressStr string, channelStr string) (*i2c
 
 func main() {
 	// set flagged arguments for TCA9548A address and channel
-	tcaAddressFlag := flag.String("tca_address", "0x70", "I2C address of the TCA9548A multiplexer (default: 0x70)") // Initialize host and I2C bus
+	tcaAddressFlag := flag.String("tca-address", "0x70", "I2C address of the TCA9548A multiplexer (default: 0x70)") // Initialize host and I2C bus
 	channelFlag := flag.Int("channel", 0, "Channel number on the TCA9548A multiplexer (0-7, default: 0)")
 
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -82,10 +82,10 @@ func initializeI2C() (i2c.BusCloser, error) {
 
 func getDevice(bus i2c.BusCloser, tcaAddressStr string, channelStr string) (*i2c.Dev, error) {
 	tcaAddress64, err := strconv.ParseUint(tcaAddressStr, 0, 16) // 0 for auto-detection of base (0x prefix means hex)
-	tcaAddress := uint16(tcaAddress64)
 	if err != nil {
 		log.Fatalf("Invalid TCA address: %v", err)
 	}
+	tcaAddress := uint16(tcaAddress64)
 
 	tca := &i2c.Dev{Bus: bus, Addr: tcaAddress}
 	fmt.Printf("Using TCA9548A at address: 0x%X\n", tcaAddress) // Confirm the address being used

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/binary" // For binary.BigEndian
+	"flag"
 	"fmt"
 	"log"
 	"net/http" // New import for HTTP server
@@ -69,7 +70,11 @@ func readINA260Reg(dev *i2c.Dev, reg byte) (uint16, error) {
 }
 
 func main() {
-	// Initialize host and I2C bus
+	// set flagged arguments for TCA9548A address and channel
+	tcaAddressFlag := flag.String("tca_address", "0x70", "I2C address of the TCA9548A multiplexer (default: 0x70)") // Initialize host and I2C bus
+	channelFlag := flag.Int("channel", 0, "Channel number on the TCA9548A multiplexer (0-7, default: 0)")
+
+	flag.Parse()
 	if _, err := host.Init(); err != nil {
 		log.Fatal(err)
 	}
@@ -88,17 +93,11 @@ func main() {
 
 	// --- Get TCA's address as argument and assign it to tcaAddress ---
 	// Get the TCA address and channel number as arguments
-	var tcaAddressStr string
-	var channelStr string
+	// Get the TCA address and channel number from flags
+	tcaAddressStr := *tcaAddressFlag
+	channelStr := strconv.Itoa(*channelFlag)
 
-	if len(os.Args) < 3 {
-		fmt.Println("No arguments or less than 2 arguments provided. Using default TCA address 0x70 and channel 0.")
-		tcaAddressStr = "0x70"
-		channelStr = "0"
-	} else {
-		tcaAddressStr = os.Args[1]
-		channelStr = os.Args[2] // Now channel number is the second argument
-	}
+	fmt.Printf("Using TCA address: %s, Channel: %s\n", tcaAddressStr, channelStr)
 
 	tcaAddress64, err := strconv.ParseUint(tcaAddressStr, 0, 16) // 0 for auto-detection of base (0x prefix means hex)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -121,7 +121,10 @@ func main() {
 
 	flag.Parse()
 	bus, err := initializeI2C() // Initialize I2C bus
-	defer bus.Close()           // Ensure the bus is closed when done
+	if err != nil {
+		log.Fatalf("Failed to initialize I2C: %v", err)
+	}
+	defer bus.Close() // Ensure the bus is closed when done
 
 	// -------------------- Set Hostname Label --------------------
 	hostname, err := os.Hostname()


### PR DESCRIPTION
This pull request refactors the `main.go` file to modularize the code, improve error handling, and introduce command-line flags for better configurability. The most important changes include splitting the `main` function into smaller, reusable functions, replacing hardcoded arguments with `flag`-based inputs, and enhancing error messages for better debugging.

### Code modularization:
* Extracted I2C initialization logic into a new `initializeI2C` function to encapsulate the setup process and improve readability. (`main.go`, [main.goL71-R143](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L71-R143))
* Created a `getDevice` function to handle device initialization, including channel selection and communication verification, simplifying the main logic. (`main.go`, [main.goL71-R143](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L71-R143))

### Improved configurability:
* Replaced hardcoded arguments for TCA9548A address and channel with command-line flags (`-tca-address` and `-channel`) using the `flag` package. This allows users to customize inputs more easily. (`main.go`, [main.goL71-R143](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L71-R143))

### Enhanced error handling:
* Replaced `log.Fatal` calls with `fmt.Errorf` for better error propagation and more descriptive error messages. (`main.go`, [main.goL71-R143](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L71-R143))

### Additional improvements:
* Added the `net/http` package import, possibly for future HTTP server functionality. (`main.go`, [main.goR5](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R5))