### PR TITLE
Dev/merge two modes

### DIFF
--- a/main.go
+++ b/main.go
@@ -162,14 +162,11 @@ func main() {
 		if *withoutMultiplexerFlag {
 			log.Fatalf("Failed to get INA260 device directly: %v", err)
 		} else {
-			fmt.Printf("Failed to get INA260 device through TCA9548A: %v", err)
-			fmt.Printf("Trying to get INA260 directly without TCA9548A...\n")
-			ina260, err = getDevice(bus, "", "") // Try to get INA260 directly without TCA9548A
-			if err != nil {
+			log.Printf("Failed to get INA260 through TCA9548A: %v. Retrying without multiplexer...", err)
+			if ina260, err = getDevice(bus, "", ""); err != nil {
 				log.Fatalf("Failed to get INA260 device directly: %v", err)
-			} else {
-				fmt.Println("Successfully connected to INA260 directly.")
 			}
+			fmt.Println("Successfully connected to INA260 directly.")
 		}
 	} else {
 		fmt.Println("Successfully connected to INA260")


### PR DESCRIPTION
This pull request introduces support for running the program without the TCA9548A I2C multiplexer, allowing direct connection to the INA260 device. The changes include adding a new flag to specify this mode, updating the logic to handle scenarios with or without the multiplexer, and ensuring proper error handling in both cases.

### New functionality for multiplexer handling:

* **Added a new flag to bypass the multiplexer**: Introduced the `--without-multiplexer` flag to indicate that the INA260 is connected directly without the TCA9548A multiplexer. Default behavior assumes the multiplexer is used. (`main.go`, [main.goR122](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R122))

* **Conditional logic for multiplexer usage**: Updated the `main` function to conditionally set the TCA address and channel based on the `--without-multiplexer` flag. If the flag is set, the program skips multiplexer-related logic. (`main.go`, [main.goL138-R173](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L138-R173))

### Error handling improvements:

* **Fallback logic for connection failures**: Enhanced the `getDevice` function to retry connecting to the INA260 directly if the initial attempt through the multiplexer fails. This ensures robustness in multiplexer-related failures. (`main.go`, [main.goL138-R173](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L138-R173))

* **Validation for TCA address and channel**: Added checks to ensure the TCA address and channel are only used when both are provided, preventing invalid configurations. (`main.go`, [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R84) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L108-R109)