### PR TITLE
feat(build): add initial Ninja build configuration and logging for Golang

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -1,0 +1,25 @@
+ninja_required_version = 1.7
+
+go = go
+src = main.go
+bin = rbp-control
+
+rule go_get
+  command = ${go} get -v
+
+rule go_build
+  command = GOOS=${go_os} GOARCH=${go_arch} ${go} build -o ${bin}-${go_os}-${go_arch} ${src}
+
+build get: go_get
+
+build linux_arm64: go_build
+  go_os = linux
+  go_arch = arm64
+  depends = get
+
+build linux_amd64: go_build
+  go_os = linux
+  go_arch = amd64
+  depends = get
+
+build all: phony linux_arm64 linux_amd64


### PR DESCRIPTION
This pull request introduces a new `build.ninja` file to define build rules for a Go project. The changes establish build configurations for different target platforms and streamline the build process using Ninja.

Build system setup:

* [`build.ninja`](diffhunk://#diff-e98202262dc5a1c181b2494cb7ef44f48ef5614dee7e4b97d5ab913f023abdd8R1-R25): Added definitions for build rules, including `go_get` for fetching dependencies and `go_build` for compiling the project for specific platforms (`linux_arm64` and `linux_amd64`). A phony target `all` was also added to build all configurations.