### PR TITLE
feat(build): add initial Ninja build configuration and logging

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -1,0 +1,25 @@
+ninja_required_version = 1.7
+
+go = go
+src = main.go
+bin = rbp-control
+
+rule go_get
+  command = ${go} get -v
+
+rule go_build
+  command = GOOS=${go_os} GOARCH=${go_arch} ${go} build -o ${bin}-${go_os}-${go_arch} ${src}
+
+build get: go_get
+
+build linux_arm64: go_build
+  go_os = linux
+  go_arch = arm64
+  depends = get
+
+build linux_amd64: go_build
+  go_os = linux
+  go_arch = amd64
+  depends = get
+
+build all: phony linux_arm64 linux_amd64


### PR DESCRIPTION
This pull request introduces a new `build.ninja` file to define a build system for the project, enabling streamlined builds for different platforms. The most important changes involve specifying build rules and targets for cross-compilation.

### Build system setup:

* Added `ninja_required_version = 1.7` to specify the minimum required Ninja version.
* Defined `go_get` and `go_build` rules for fetching dependencies and building the Go project, respectively.
* Added build targets for `linux_arm64` and `linux_amd64`, allowing cross-compilation for these platforms. Each target depends on the `go_get` rule.
* Introduced a `build all` target to build all supported platforms (`linux_arm64` and `linux_amd64`) as a phony target.