### PR TITLE
fix: allow customizable I2C bus selection during initialization

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,11 +69,11 @@ func readINA260Reg(dev *i2c.Dev, reg byte) (uint16, error) {
 	return binary.BigEndian.Uint16(readBuf), nil
 }
 
-func initializeI2C() (i2c.BusCloser, error) {
+func initializeI2C(busFlag string) (i2c.BusCloser, error) {
 	if _, err := host.Init(); err != nil {
 		return nil, fmt.Errorf("failed to initialize host: %w", err)
 	}
-	bus, err := i2creg.Open("") // Opens the default I2C bus
+	bus, err := i2creg.Open(busFlag) // Opens the default I2C bus
 	if err != nil {
 		return nil, fmt.Errorf("failed to open I2C bus: %w", err)
 	}
@@ -120,9 +120,10 @@ func main() {
 	tcaAddressFlag := flag.String("tca-address", "0x70", "I2C address of the TCA9548A multiplexer (default: 0x70)") // Initialize host and I2C bus
 	channelFlag := flag.Int("channel", 0, "Channel number on the TCA9548A multiplexer (0-7, default: 0)")
 	withoutMultiplexerFlag := flag.Bool("without-multiplexer", false, "Set to true if INA260 is connected directly without TCA9548A multiplexer (default: false)")
+	busFlag := flag.String("bus", "/dev/i2c-1", "I2C bus to use (default: /dev/i2c-1)")
 
 	flag.Parse()
-	bus, err := initializeI2C() // Initialize I2C bus
+	bus, err := initializeI2C(*busFlag) // Initialize I2C bus
 	if err != nil {
 		log.Fatalf("Failed to initialize I2C: %v", err)
 	}


### PR DESCRIPTION
This pull request introduces an enhancement to the I2C initialization process by allowing users to specify the I2C bus to use via a command-line flag. This change improves flexibility in environments with multiple I2C buses.

### Enhancements to I2C initialization:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L72-R76): Modified the `initializeI2C` function to accept a `busFlag` parameter, enabling the selection of a specific I2C bus instead of defaulting to the system's default bus.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R123-R126): Added a new command-line flag `bus` to allow users to specify the I2C bus path (e.g., `/dev/i2c-1`) when running the program. Updated the `main` function to pass this flag to `initializeI2C`.